### PR TITLE
1.21.1 neoforge edition

### DIFF
--- a/config/dailyshop/trade_tables/2_2_create.json
+++ b/config/dailyshop/trade_tables/2_2_create.json
@@ -11,13 +11,13 @@
     }
   },
   "output": [
-{ "item": "create:brass_funnel", "count": { "type": "constant", "count": 2 }, "weight": 6.0 },
-{ "item": "create:brass_tunnel", "count": { "type": "constant", "count": 1 }, "weight": 6.0 },
-{ "item": "create:electron_tube", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
-{ "item": "create:gearbox", "count": { "type": "constant", "count": 8 }, "weight": 3.0 },
-{ "item": "create:encased_chain_drive", "count": { "type": "constant", "count": 4 }, "weight": 4.0 },
-{ "item": "create:belt_connector", "count": { "type": "constant", "count": 4 }, "weight": 4.0 },
-{ "item": "create:item_vault", "count": { "type": "constant", "count": 4 }, "weight": 2.5},
-{ "item": "create:deployer", "count": { "type": "constant", "count": 4 }, "weight": 4.0 }
+{ "item": "create:brass_funnel", "count": { "type": "constant", "count": 2 }, "weight": 1.0 },
+{ "item": "create:brass_tunnel", "count": { "type": "constant", "count": 1 }, "weight": 1.0 },
+{ "item": "create:electron_tube", "count": { "type": "constant", "count": 2 }, "weight": 0.2 },
+{ "item": "create:gearbox", "count": { "type": "constant", "count": 8 }, "weight": 0.3 },
+{ "item": "create:encased_chain_drive", "count": { "type": "constant", "count": 4 }, "weight": 0.7 },
+{ "item": "create:belt_connector", "count": { "type": "constant", "count": 4 }, "weight": 0.7 },
+{ "item": "create:item_vault", "count": { "type": "constant", "count": 4 }, "weight": 0.8},
+{ "item": "create:deployer", "count": { "type": "constant", "count": 4 }, "weight": 0.5 }
   ]
 }

--- a/config/dailyshop/trade_tables/3_ingots.json
+++ b/config/dailyshop/trade_tables/3_ingots.json
@@ -11,12 +11,12 @@
     }
   },
   "output": [
-	{"item": "minecraft:iron_ingot", "count": {"type": "constant", "count": 8}, "weight": 10.0},
-	{"item": "minecraft:copper_ingot", "count": {"type": "constant", "count": 12}, "weight": 8.0},
-	{"item": "minecraft:gold_ingot", "count": {"type": "constant", "count": 4}, "weight": 6.0},
-	{"item": "minecraft:redstone", "count": {"type": "constant", "count": 24}, "weight": 1.0},
-  {"item": "minecraft:diamond", "count": {"type": "constant", "count": 4}, "weight": 1.0},
-	{"item": "create:zinc_ingot", "count": {"type": "constant", "count": 12}, "weight": 3.0},
-	{"item": "oritech:nickel_ingot", "count": {"type": "constant", "count": 8 }, "weight": 2.0}
+	{"item": "minecraft:iron_ingot", "count": {"type": "constant", "count": 8}, "weight": 2.0},
+	{"item": "minecraft:copper_ingot", "count": {"type": "constant", "count": 12}, "weight": 1.5},
+	{"item": "minecraft:gold_ingot", "count": {"type": "constant", "count": 4}, "weight": 0.5},
+	{"item": "minecraft:redstone", "count": {"type": "constant", "count": 24}, "weight": 0.5},
+  {"item": "minecraft:diamond", "count": {"type": "constant", "count": 4}, "weight": 0.25},
+	{"item": "create:zinc_ingot", "count": {"type": "constant", "count": 12}, "weight": 0.75},
+	{"item": "oritech:nickel_ingot", "count": {"type": "constant", "count": 8 }, "weight": 0.5}
   ]
 }

--- a/config/dailyshop/trade_tables/6_1_seeds.json
+++ b/config/dailyshop/trade_tables/6_1_seeds.json
@@ -7,11 +7,26 @@
 { "filter": "kubejs:gold_coins", "count": { "type": "constant", "count": 4 } },
 "output": [
   { "item": "wheat_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
-  { "item": "pumpkin_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
-  { "item": "melon_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "pumpkin_seeds", "count": { "type": "constant", "count": 4 }, "weight": 0.5 },
+  { "item": "melon_seeds", "count": { "type": "constant", "count": 4 }, "weight": 0.3 },
   { "item": "farmersdelight:cabbage_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
   { "item": "farmersdelight:tomato_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
-  { "item": "torchflower_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
-  { "item": "beetroot_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 }
+  { "item": "minecolonies:tomato", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:soybean", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:onion", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:eggplant", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:durum", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:chickpea", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:cabbage", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:bell_pepper", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:garlic", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:butternut_squash", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:mint", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:peas", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:nether_pepper", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:corn", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "minecolonies:rice", "count": { "type": "constant", "count": 4 }, "weight": 0.2 },
+  { "item": "torchflower_seeds", "count": { "type": "constant", "count": 4 }, "weight": 0.3 },
+  { "item": "beetroot_seeds", "count": { "type": "constant", "count": 4 }, "weight": 0.8 }
 ]
 }

--- a/config/dailyshop/trade_tables/6_2_seeds.json
+++ b/config/dailyshop/trade_tables/6_2_seeds.json
@@ -7,11 +7,11 @@
 { "filter": "kubejs:emerald_coins", "count": { "type": "constant", "count": 4 } },
 "output": [
   { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
+  { "item": "cobblemon:blue_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
+  { "item": "cobblemon:cyan_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
+  { "item": "cobblemon:pink_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
+  { "item": "cobblemon:green_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
+  { "item": "cobblemon:white_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
   { "item": "cobblemon:vivichoke_seeds", "count": { "type": "constant", "count": 1 }, "weight": 1.0 }
 ]
 }

--- a/config/dailyshop/trade_tables/6_2_seeds.json
+++ b/config/dailyshop/trade_tables/6_2_seeds.json
@@ -6,12 +6,12 @@
 "input1": 
 { "filter": "kubejs:emerald_coins", "count": { "type": "constant", "count": 4 } },
 "output": [
-  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:blue_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:cyan_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:pink_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:green_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:white_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 5.0 },
-  { "item": "cobblemon:vivichoke_seeds", "count": { "type": "constant", "count": 1 }, "weight": 1.0 }
+  { "item": "cobblemon:red_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:blue_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:cyan_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:pink_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:green_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:white_mint_seeds", "count": { "type": "constant", "count": 4 }, "weight": 1.0 },
+  { "item": "cobblemon:vivichoke_seeds", "count": { "type": "constant", "count": 1 }, "weight": 0.2 }
 ]
 }

--- a/config/dailyshop/trade_tables/8_2_irons_gems_scrolls.json
+++ b/config/dailyshop/trade_tables/8_2_irons_gems_scrolls.json
@@ -4,7 +4,7 @@
     "count": 1
   },
 "input1": 
-{ "filter": "kubejs:energium_coins", "count": { "type": "constant", "count": 2 } },
+{ "filter": "kubejs:energite_coins", "count": { "type": "constant", "count": 2 } },
 "output": [
   { "item": "kubejs:irons_amulet_of_protection", "count": { "type": "constant", "count": 1 }, "weight": 1.0 },
   { "item": "kubejs:irons_bane_ring", "count": { "type": "constant", "count": 1 }, "weight": 0.7 },

--- a/config/dailyshop/trade_tables/9_mega.json
+++ b/config/dailyshop/trade_tables/9_mega.json
@@ -8,9 +8,8 @@
 "output": [
   { "item": "mega_showdown:mega_stone", "count": { "type": "constant", "count": 1 }, "weight": 1.0 },
   { "item": "mega_showdown:blank-z", "count": { "type": "constant", "count": 1 }, "weight": 1.0 },
-  { "item": "mega_showdown:zygarde_core", "count": { "type": "constant", "count": 1 }, "weight": 0.02 },
-  { "item": "mega_showdown:zygarde_cube", "count": { "type": "constant", "count": 1 }, "weight": 0.02 },
-  { "item": "mega_showdown:zygarde_cell", "count": { "type": "constant", "count": 1 }, "weight": 0.02 },
+  { "item": "mega_showdown:zygarde_core", "count": { "type": "constant", "count": 3 }, "weight": 0.02 },
+  { "item": "mega_showdown:zygarde_cell", "count": { "type": "constant", "count": 8 }, "weight": 0.1 },
   { "item": "minecraft:enchanted_golden_apple", "count": { "type": "constant", "count": 1 }, "weight": 1.0}
 ]
 }

--- a/config/dailyshop/trade_tables/daily_shop.json
+++ b/config/dailyshop/trade_tables/daily_shop.json
@@ -5,17 +5,17 @@
   },
   "pool": [
     {"value": "1_artifacts", "weight": 0.1},
-    {"value": "2_1_create", "weight": 1.2},
+    {"value": "2_1_create", "weight": 1.0},
     {"value": "2_2_create", "weight": 0.8},
     {"value": "3_ingots", "weight": 1.0},
-    {"value": "4_pokeballs", "weight": 1.5},
+    {"value": "4_pokeballs", "weight": 1.0},
     {"value": "5_saplings", "weight": 1.0},
     {"value": "6_1_seeds", "weight": 1.0},
-    {"value": "6_2_seeds", "weight": 1.0},
+    {"value": "6_2_seeds", "weight": 0.8},
     {"value": "7_immersive_aircrafts", "weight": 0.4},
     {"value": "8_1_irons_gems", "weight": 0.5},
-    {"value": "8_2_irons_gems_scrolls", "weight": 0.5},
-    {"value": "8_3_irons_gems_scrolls_superior", "weight": 0.2},
+    {"value": "8_2_irons_gems_scrolls", "weight": 0.3},
+    {"value": "8_3_irons_gems_scrolls_superior", "weight": 0.1},
     {"value": "9_mega", "weight": 0.3}
   ]
 }

--- a/kubejs/data/minecolonies/crafterrecipes/blacksmith/evil_eye.json
+++ b/kubejs/data/minecolonies/crafterrecipes/blacksmith/evil_eye.json
@@ -1,6 +1,6 @@
 {
   "type": "recipe",
-  "crafter": "enchanter_custom",
+  "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "count": 1,

--- a/kubejs/data/minecolonies/crafterrecipes/enchanter/undead_eye.json
+++ b/kubejs/data/minecolonies/crafterrecipes/enchanter/undead_eye.json
@@ -1,6 +1,6 @@
 {
   "type": "recipe",
-  "crafter": "blacksmith_crafting",
+  "crafter": "enchanter_custom",
   "inputs": [
     {
       "id": "minecraft:bone"


### PR DESCRIPTION
- Some table weights were set too high relative to the others.
- Adujsted overall weights in tables, i.e. tier two seeds being rarer than tier 1. Considering reducing availible trades to 5 to make the UI cleaner.
- Removed Zygarde Crystal availability in shop as it is craftable. Further plans for Z Crystals / Mega Stones.
- Fixed red mint seeds seeds being listed six times.
- Now shows all cobblemon mint seeds appropriately.
- Changed KubeJS: Energium Coins to match its actual name,
Energite Coins
Evil Eye (which looks like it could be made out of gold and lapis) is supposed to be in the blacksmith's toolkit.
Undead Eye (which is cheaper, and involves dark arts [supposedly]) should be tied to the enchanter, with the enchanter being a late-colony drop.